### PR TITLE
Fix ZIP64 EOCD size to exclude leading 12 bytes

### DIFF
--- a/gsf/gsf-outfile-zip.c
+++ b/gsf/gsf-outfile-zip.c
@@ -300,7 +300,7 @@ zip_trailer64_write (GsfOutfileZip *zip, unsigned entries,
 
 	memset (buf, 0, sizeof buf);
 	GSF_LE_SET_GUINT32 (buf, ZIP_TRAILER64_SIGNATURE);
-	GSF_LE_SET_GUINT64 (buf + ZIP_TRAILER64_RECSIZE, sizeof buf);
+	GSF_LE_SET_GUINT64 (buf + ZIP_TRAILER64_RECSIZE, sizeof buf - 12);
 	GSF_LE_SET_GUINT16 (buf + ZIP_TRAILER64_ENCODER,
 			    (ZIP_OS_UNIX << 8) + extract);
 	GSF_LE_SET_GUINT16 (buf + ZIP_TRAILER64_EXTRACT,


### PR DESCRIPTION
This fixes a wrong value in the ZIP64 EOCD size field, which wrongly includes leading bytes.

From the [PKWARE spec](https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT):

> 4.3.14.1 The value stored into the "size of zip64 end of central
> directory record" should be the size of the remaining
> record and should not include the leading 12 bytes.
> 
> Size = SizeOfFixedFields + SizeOfVariableData - 12.

**Without this Fix verification with 7-Zip fails:**

```
$ 7za t world-86400x43200-gm2.zip

7-Zip (a) [64] 15.14 : Copyright (c) 1999-2015 Igor Pavlov : 2015-12-31
p7zip Version 15.14.1 (locale=utf8,Utf16=on,HugeFiles=on,64 bits,4 CPUs x64)

Scanning the drive for archives:
1 file, 313438881 bytes (299 MiB)

Testing archive: world-86400x43200-gm2.zip
ERROR: world-86400x43200-gm2.zip
world-86400x43200-gm2.zip
Open ERROR: Can not open the file as [zip] archive


WARNINGS:
There are data after the end of archive

Can't open as archive: 1
Files: 0
Size:       0
Compressed: 0
```

**After Fix:**

```
$ 7za t world-86400x43200-gm2-eocdfix.zip

7-Zip (a) [64] 15.14 : Copyright (c) 1999-2015 Igor Pavlov : 2015-12-31
p7zip Version 15.14.1 (locale=utf8,Utf16=on,HugeFiles=on,64 bits,4 CPUs x64)

Scanning the drive for archives:
1 file, 313438881 bytes (299 MiB)

Testing archive: world-86400x43200-gm2-eocdfix.zip
--
Path = world-86400x43200-gm2-eocdfix.zip
Type = zip
Physical Size = 313438881
64-bit = +

Everything is Ok

Files: 76424
Size:       299563749
Compressed: 313438881
```
