### PR TITLE
Fix the zip noise tests on MacOS X and other BSDs

### DIFF
--- a/tests/t1003-zip-noise.pl
+++ b/tests/t1003-zip-noise.pl
@@ -8,6 +8,6 @@ use FileHandle;
 
 my $noise = 'noise.bin';
 &LibGsfTest::junkfile ($noise);
-system ("dd", "if=/dev/urandom", "of=$noise", "bs=1M", "count=10");
+system ("dd", "if=/dev/urandom", "of=$noise", "bs=1048576", "count=10");
 &test_zip ('files' => [$noise],
 	   'zip-member-tests' => ['!zip64']);


### PR DESCRIPTION
The BSD version of dd uses lower case units, while the Linux version uses upper case.
For compatibility with both platforms we can use bytes instead.
